### PR TITLE
chore: test swagger docs for openapi2aspida

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,6 +26,17 @@ jobs:
     - name: Test
       run: go test -v ./...
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js version
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+      - name: Test generated swagger docs
+        run: npm i openapi2aspida && npx openapi2aspida -i docs/swagger.yaml
+
   golangci:
     name: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 説明
- FEで`openapi2aspida`に失敗するので、GitHub Actionsにテストコードを追加しました。

## 備考
- `614b76350d51e91e95cb71daeaac7920d638d146`のコミットの時点で既に`swagger.yaml`に不備がある。