### PR TITLE
Feat: アプリケーション用のカスタムエラー作成

### DIFF
--- a/internal/controller/ar_assets/ar_assets_controller.go
+++ b/internal/controller/ar_assets/ar_assets_controller.go
@@ -1,11 +1,13 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/Misoten-B/airship-backend/internal/controller/ar_assets/dto"
+	"github.com/Misoten-B/airship-backend/internal/customerror"
 	"github.com/Misoten-B/airship-backend/internal/database"
 	threeservice "github.com/Misoten-B/airship-backend/internal/domain/three_dimentional_model/service"
 	voiceservice "github.com/Misoten-B/airship-backend/internal/domain/voice/service"
@@ -111,7 +113,17 @@ func CreateArAssets(c *gin.Context) {
 	output, err := usecaseImpl.Create(input)
 
 	if err != nil {
-		log.Printf("%s", err)
+		var appErr *customerror.ApplicationError
+
+		if !errors.As(err, &appErr) {
+			log.Printf("%s", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		if appErr.IsInternalError() {
+			log.Printf("%s", err)
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/controller/ar_assets/ar_assets_controller.go
+++ b/internal/controller/ar_assets/ar_assets_controller.go
@@ -31,28 +31,26 @@ func CreateArAssets(c *gin.Context) {
 	// コンテキストから取得
 	config, err := frameworks.GetConfig(c)
 	if err != nil {
-		log.Printf("%s", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		frameworks.ErrorHandling(c, err, http.StatusInternalServerError)
 		return
 	}
 
 	uid, err := frameworks.GetUID(c)
 	if err != nil {
-		log.Printf("%s", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		frameworks.ErrorHandling(c, err, http.StatusInternalServerError)
 		return
 	}
 
 	// リクエスト取得
 	request := dto.CreateArAssetsRequest{}
 	if err = c.ShouldBind(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		frameworks.ErrorHandling(c, err, http.StatusBadRequest)
 		return
 	}
 
 	file, fileHeader, err := c.Request.FormFile("qrcodeIcon")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		frameworks.ErrorHandling(c, err, http.StatusBadRequest)
 		return
 	}
 
@@ -72,15 +70,13 @@ func CreateArAssets(c *gin.Context) {
 			usecase.WithThreeDimentionalModelServiceImpl(tmodelRepo),
 		)
 		if err != nil {
-			log.Printf("%s", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			frameworks.ErrorHandling(c, err, http.StatusInternalServerError)
 			return
 		}
 	} else {
 		db, dbErr := database.ConnectDB()
 		if dbErr != nil {
-			log.Printf("%s", dbErr)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": dbErr.Error()})
+			frameworks.ErrorHandling(c, dbErr, http.StatusInternalServerError)
 			return
 		}
 
@@ -95,8 +91,7 @@ func CreateArAssets(c *gin.Context) {
 			usecase.WithThreeDimentionalModelServiceImpl(tmodelRepo),
 		)
 		if err != nil {
-			log.Printf("%s", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			frameworks.ErrorHandling(c, err, http.StatusInternalServerError)
 			return
 		}
 	}
@@ -115,16 +110,11 @@ func CreateArAssets(c *gin.Context) {
 	if err != nil {
 		var appErr *customerror.ApplicationError
 
-		if !errors.As(err, &appErr) {
-			log.Printf("%s", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		if errors.As(err, &appErr) {
+			frameworks.ErrorHandling(c, err, appErr.StatusCode())
 			return
 		}
-
-		if appErr.IsInternalError() {
-			log.Printf("%s", err)
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		frameworks.ErrorHandling(c, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/customerror/error.go
+++ b/internal/customerror/error.go
@@ -1,6 +1,9 @@
 package customerror
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 type ApplicationError struct {
 	message    string
@@ -9,7 +12,9 @@ type ApplicationError struct {
 	details string
 }
 
-func NewApplicationError(message string, statusCode int, details string) error {
+func NewApplicationError(err error, message string, statusCode int) error {
+	details := fmt.Sprintf("%s: %s", message, err.Error())
+
 	return &ApplicationError{
 		message:    message,
 		statusCode: statusCode,

--- a/internal/customerror/error.go
+++ b/internal/customerror/error.go
@@ -1,5 +1,7 @@
 package customerror
 
+import "net/http"
+
 type ApplicationError struct {
 	message    string
 	statusCode int
@@ -15,6 +17,14 @@ func NewApplicationError(message string, statusCode int, details string) error {
 	}
 }
 
+func NewApplicationErrorWithoutDetails(message string, statusCode int) error {
+	return &ApplicationError{
+		message:    message,
+		statusCode: statusCode,
+		details:    message,
+	}
+}
+
 func (e *ApplicationError) Error() string {
 	return e.message
 }
@@ -26,4 +36,8 @@ func (e *ApplicationError) StatusCode() int {
 // Details は開発者向けのエラー詳細を返します。
 func (e *ApplicationError) Details() string {
 	return e.details
+}
+
+func (e *ApplicationError) IsInternalError() bool {
+	return e.statusCode == http.StatusInternalServerError
 }

--- a/internal/customerror/error.go
+++ b/internal/customerror/error.go
@@ -1,0 +1,29 @@
+package customerror
+
+type ApplicationError struct {
+	message    string
+	statusCode int
+	// details は開発者向けのエラー詳細を格納します。
+	details string
+}
+
+func NewApplicationError(message string, statusCode int, details string) error {
+	return &ApplicationError{
+		message:    message,
+		statusCode: statusCode,
+		details:    details,
+	}
+}
+
+func (e *ApplicationError) Error() string {
+	return e.message
+}
+
+func (e *ApplicationError) StatusCode() int {
+	return e.statusCode
+}
+
+// Details は開発者向けのエラー詳細を返します。
+func (e *ApplicationError) Details() string {
+	return e.details
+}

--- a/internal/customerror/error_test.go
+++ b/internal/customerror/error_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestApplicationError(t *testing.T) {
-	err := customerror.NewApplicationError(
+	err := customerror.NewApplicationErrorWithoutDetails(
 		"test error",
 		http.StatusBadRequest,
-		"test details",
 	)
 
 	var appErr *customerror.ApplicationError

--- a/internal/customerror/error_test.go
+++ b/internal/customerror/error_test.go
@@ -1,0 +1,26 @@
+package customerror_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Misoten-B/airship-backend/internal/customerror"
+)
+
+func TestApplicationError(t *testing.T) {
+	err := customerror.NewApplicationError(
+		"test error",
+		http.StatusBadRequest,
+		"test details",
+	)
+
+	var appErr *customerror.ApplicationError
+	if errors.As(err, &appErr) {
+		t.Logf("error message: %s", appErr.Error())
+		t.Logf("error status code: %d", appErr.StatusCode())
+		t.Logf("error details: %s", appErr.Details())
+	} else {
+		t.Errorf("error is not *customerror.ApplicationError")
+	}
+}

--- a/internal/frameworks/errorhandling.go
+++ b/internal/frameworks/errorhandling.go
@@ -1,0 +1,30 @@
+package frameworks
+
+import (
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/Misoten-B/airship-backend/internal/customerror"
+	"github.com/gin-gonic/gin"
+)
+
+// ErrorHandling はGinのHTTPハンドラ用のエラーハンドリングを行います。
+// 内部エラーの場合はログを出力します。
+func ErrorHandling(c *gin.Context, err error, statusCode int) {
+	if err == nil {
+		return
+	}
+
+	if statusCode == http.StatusInternalServerError {
+		var appErr *customerror.ApplicationError
+
+		if errors.As(err, &appErr) {
+			log.Printf("%s", appErr.Details())
+		} else {
+			log.Printf("%s", err.Error())
+		}
+	}
+
+	c.JSON(statusCode, gin.H{"error": err.Error()})
+}

--- a/internal/usecase/ar_assets.go
+++ b/internal/usecase/ar_assets.go
@@ -1,7 +1,6 @@
 package usecase
 
 import (
-	"fmt"
 	"mime/multipart"
 	"net/http"
 
@@ -87,9 +86,9 @@ func (u *ARAssetsUsecaseImpl) Create(input ARAssetsCreateInput) (ARAssetsCreateO
 	if err != nil {
 		msg := "failed to check if voice model generation is complete"
 		return output, customerror.NewApplicationError(
+			err,
 			msg,
 			http.StatusInternalServerError,
-			fmt.Sprintf("%s: %s", msg, err.Error()),
 		)
 	}
 	if !isCompleted {
@@ -104,9 +103,9 @@ func (u *ARAssetsUsecaseImpl) Create(input ARAssetsCreateInput) (ARAssetsCreateO
 	if err != nil {
 		msg := "failed to check if user has permission to use this 3D model"
 		return output, customerror.NewApplicationError(
+			err,
 			msg,
 			http.StatusInternalServerError,
-			fmt.Sprintf("%s: %s", msg, err.Error()),
 		)
 	}
 	if !hasPermission {
@@ -128,9 +127,9 @@ func (u *ARAssetsUsecaseImpl) Create(input ARAssetsCreateInput) (ARAssetsCreateO
 	if err != nil {
 		msg := "failed to generate audio file"
 		return output, customerror.NewApplicationError(
+			err,
 			msg,
 			http.StatusInternalServerError,
-			fmt.Sprintf("%s: %s", msg, err.Error()),
 		)
 	}
 
@@ -139,9 +138,9 @@ func (u *ARAssetsUsecaseImpl) Create(input ARAssetsCreateInput) (ARAssetsCreateO
 	if err != nil {
 		msg := "failed to save QR code image"
 		return output, customerror.NewApplicationError(
+			err,
 			msg,
 			http.StatusInternalServerError,
-			fmt.Sprintf("%s: %s", msg, err.Error()),
 		)
 	}
 
@@ -150,9 +149,9 @@ func (u *ARAssetsUsecaseImpl) Create(input ARAssetsCreateInput) (ARAssetsCreateO
 	if err != nil {
 		msg := "failed to save AR assets"
 		return output, customerror.NewApplicationError(
+			err,
 			msg,
 			http.StatusInternalServerError,
-			fmt.Sprintf("%s: %s", msg, err.Error()),
 		)
 	}
 


### PR DESCRIPTION
## 関連isuue

close #42 

## 説明

カスタムエラー構造体を作成して、ユースケースがHTTPステータスコードを返せるようにしました。

## 変更の種類

- [ ] バグ修正（問題を修正する非互換の変更）
- [x] 新機能（機能を追加する非互換の変更）
- [ ] 互換性のない変更（既存の機能が期待どおりに動作しなくなる修正または機能）

## チェックリスト:

- [x] 自己レビュー
- [x] 特に理解しにくい部分にコメントを追加
- [x] 変更によって新しい警告が発生しない

## その他
- 追記事項。そのほかお見送り事項。