### PR TITLE
hotfix: 参照している名刺の全削除

### DIFF
--- a/internal/application/usecase/ar_assets/delete_ar_assets/usecase.go
+++ b/internal/application/usecase/ar_assets/delete_ar_assets/usecase.go
@@ -106,6 +106,15 @@ func (i *Interactor) deleteFromRepository(dbModel model.ARAsset) error {
 		}
 	}()
 
+	// 参照している名刺の全削除
+	if err := tx.Where("ar_asset_id = ?", dbModel.ID).Delete(&model.BusinessCard{}).Error; err != nil {
+		return customerror.NewApplicationError(
+			fmt.Errorf("failed to delete business cards: %w", err),
+			"failed to delete business cards",
+			http.StatusInternalServerError,
+		)
+	}
+
 	// ARアセットの削除
 	if err := tx.Delete(&dbModel).Error; err != nil {
 		tx.Rollback()


### PR DESCRIPTION
## 関連isuue

## 説明

原因はGormのモデルミスだが、ここでは応急処置として参照している名刺の全削除を実施

## 変更の種類

- [ ] バグ修正（問題を修正する非互換の変更）
- [ ] 新機能（機能を追加する非互換の変更）
- [ ] 互換性のない変更（既存の機能が期待どおりに動作しなくなる修正または機能）

## チェックリスト:

- [ ] 自己レビュー
- [ ] 特に理解しにくい部分にコメントを追加
- [ ] 変更によって新しい警告が発生しない

## その他
- 追記事項。そのほかお見送り事項。